### PR TITLE
Enable the fetching of only the OCI descriptor

### DIFF
--- a/internal/rego/oci/__snapshots__/oci_test.snap
+++ b/internal/rego/oci/__snapshots__/oci_test.snap
@@ -883,7 +883,7 @@
      [
       {
        "type": "string",
-       "value": "manifest.annotation.1"
+       "value": "config.annotation.1"
       },
       {
        "type": "string",
@@ -893,7 +893,7 @@
      [
       {
        "type": "string",
-       "value": "manifest.annotation.2"
+       "value": "config.annotation.2"
       },
       {
        "type": "string",
@@ -906,406 +906,31 @@
   [
    {
     "type": "string",
-    "value": "config"
+    "value": "artifactType"
    },
    {
-    "type": "object",
-    "value": [
-     [
-      {
-       "type": "string",
-       "value": "annotations"
-      },
-      {
-       "type": "object",
-       "value": [
-        [
-         {
-          "type": "string",
-          "value": "config.annotation.1"
-         },
-         {
-          "type": "string",
-          "value": "config.annotation.value.1"
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "config.annotation.2"
-         },
-         {
-          "type": "string",
-          "value": "config.annotation.value.2"
-         }
-        ]
-       ]
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "artifactType"
-      },
-      {
-       "type": "string",
-       "value": "artifact-type"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "data"
-      },
-      {
-       "type": "string",
-       "value": "{\"data\": \"config\"}"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "digest"
-      },
-      {
-       "type": "string",
-       "value": "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "mediaType"
-      },
-      {
-       "type": "string",
-       "value": "application/vnd.oci.image.config.v1+json"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "platform"
-      },
-      {
-       "type": "object",
-       "value": [
-        [
-         {
-          "type": "string",
-          "value": "architecture"
-         },
-         {
-          "type": "string",
-          "value": "arch"
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "features"
-         },
-         {
-          "type": "array",
-          "value": [
-           {
-            "type": "string",
-            "value": "feature-1"
-           },
-           {
-            "type": "string",
-            "value": "feature-2"
-           }
-          ]
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "os"
-         },
-         {
-          "type": "string",
-          "value": "os"
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "os.features"
-         },
-         {
-          "type": "array",
-          "value": [
-           {
-            "type": "string",
-            "value": "os-feature-1"
-           },
-           {
-            "type": "string",
-            "value": "os-feature-2"
-           }
-          ]
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "os.version"
-         },
-         {
-          "type": "string",
-          "value": "os-version"
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "variant"
-         },
-         {
-          "type": "string",
-          "value": "variant"
-         }
-        ]
-       ]
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "size"
-      },
-      {
-       "type": "number",
-       "value": 123
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "urls"
-      },
-      {
-       "type": "array",
-       "value": [
-        {
-         "type": "string",
-         "value": "https://config-1.local/spam"
-        },
-        {
-         "type": "string",
-         "value": "https://config-2.local/spam"
-        }
-       ]
-      }
-     ]
-    ]
+    "type": "string",
+    "value": "artifact-type"
    }
   ],
   [
    {
     "type": "string",
-    "value": "layers"
+    "value": "data"
    },
    {
-    "type": "array",
-    "value": [
-     {
-      "type": "object",
-      "value": [
-       [
-        {
-         "type": "string",
-         "value": "annotations"
-        },
-        {
-         "type": "object",
-         "value": [
-          [
-           {
-            "type": "string",
-            "value": "layer.annotation.1"
-           },
-           {
-            "type": "string",
-            "value": "layer.annotation.value.1"
-           }
-          ],
-          [
-           {
-            "type": "string",
-            "value": "layer.annotation.2"
-           },
-           {
-            "type": "string",
-            "value": "layer.annotation.value.2"
-           }
-          ]
-         ]
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "artifactType"
-        },
-        {
-         "type": "string",
-         "value": "artifact-type"
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "data"
-        },
-        {
-         "type": "string",
-         "value": "{\"data\": \"layer\"}"
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "digest"
-        },
-        {
-         "type": "string",
-         "value": "sha256:325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67"
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "mediaType"
-        },
-        {
-         "type": "string",
-         "value": "application/vnd.oci.image.layer.v1.tar+gzip"
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "platform"
-        },
-        {
-         "type": "object",
-         "value": [
-          [
-           {
-            "type": "string",
-            "value": "architecture"
-           },
-           {
-            "type": "string",
-            "value": "arch"
-           }
-          ],
-          [
-           {
-            "type": "string",
-            "value": "features"
-           },
-           {
-            "type": "array",
-            "value": [
-             {
-              "type": "string",
-              "value": "feature-1"
-             },
-             {
-              "type": "string",
-              "value": "feature-2"
-             }
-            ]
-           }
-          ],
-          [
-           {
-            "type": "string",
-            "value": "os"
-           },
-           {
-            "type": "string",
-            "value": "os"
-           }
-          ],
-          [
-           {
-            "type": "string",
-            "value": "os.features"
-           },
-           {
-            "type": "array",
-            "value": [
-             {
-              "type": "string",
-              "value": "os-feature-1"
-             },
-             {
-              "type": "string",
-              "value": "os-feature-2"
-             }
-            ]
-           }
-          ],
-          [
-           {
-            "type": "string",
-            "value": "os.version"
-           },
-           {
-            "type": "string",
-            "value": "os-version"
-           }
-          ],
-          [
-           {
-            "type": "string",
-            "value": "variant"
-           },
-           {
-            "type": "string",
-            "value": "variant"
-           }
-          ]
-         ]
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "size"
-        },
-        {
-         "type": "number",
-         "value": 9999
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "urls"
-        },
-        {
-         "type": "array",
-         "value": [
-          {
-           "type": "string",
-           "value": "https://layer-1.local/spam"
-          },
-          {
-           "type": "string",
-           "value": "https://layer-2.local/spam"
-          }
-         ]
-        }
-       ]
-      ]
-     }
-    ]
+    "type": "string",
+    "value": "{\"data\": \"config\"}"
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "digest"
+   },
+   {
+    "type": "string",
+    "value": "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
    }
   ],
   [
@@ -1315,23 +940,13 @@
    },
    {
     "type": "string",
-    "value": "application/vnd.oci.image.manifest.v1+json"
+    "value": "application/vnd.oci.image.config.v1+json"
    }
   ],
   [
    {
     "type": "string",
-    "value": "schemaVersion"
-   },
-   {
-    "type": "number",
-    "value": 2
-   }
-  ],
-  [
-   {
-    "type": "string",
-    "value": "subject"
+    "value": "platform"
    },
    {
     "type": "object",
@@ -1339,192 +954,110 @@
      [
       {
        "type": "string",
-       "value": "annotations"
+       "value": "architecture"
       },
       {
-       "type": "object",
-       "value": [
-        [
-         {
-          "type": "string",
-          "value": "subject.annotation.1"
-         },
-         {
-          "type": "string",
-          "value": "subject.annotation.value.1"
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "subject.annotation.2"
-         },
-         {
-          "type": "string",
-          "value": "subject.annotation.value.2"
-         }
-        ]
-       ]
+       "type": "string",
+       "value": "arch"
       }
      ],
      [
       {
        "type": "string",
-       "value": "artifactType"
-      },
-      {
-       "type": "string",
-       "value": "artifact-type"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "data"
-      },
-      {
-       "type": "string",
-       "value": "{\"data\": \"subject\"}"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "digest"
-      },
-      {
-       "type": "string",
-       "value": "sha256:d9298a10d1b0735837dc4bd85dac641b0f3cef27a47e5d53a54f2f3f5b2fcffa"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "mediaType"
-      },
-      {
-       "type": "string",
-       "value": "application/vnd.oci.image.manifest.v1+json"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "platform"
-      },
-      {
-       "type": "object",
-       "value": [
-        [
-         {
-          "type": "string",
-          "value": "architecture"
-         },
-         {
-          "type": "string",
-          "value": "arch"
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "features"
-         },
-         {
-          "type": "array",
-          "value": [
-           {
-            "type": "string",
-            "value": "feature-1"
-           },
-           {
-            "type": "string",
-            "value": "feature-2"
-           }
-          ]
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "os"
-         },
-         {
-          "type": "string",
-          "value": "os"
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "os.features"
-         },
-         {
-          "type": "array",
-          "value": [
-           {
-            "type": "string",
-            "value": "os-feature-1"
-           },
-           {
-            "type": "string",
-            "value": "os-feature-2"
-           }
-          ]
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "os.version"
-         },
-         {
-          "type": "string",
-          "value": "os-version"
-         }
-        ],
-        [
-         {
-          "type": "string",
-          "value": "variant"
-         },
-         {
-          "type": "string",
-          "value": "variant"
-         }
-        ]
-       ]
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "size"
-      },
-      {
-       "type": "number",
-       "value": 8888
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "urls"
+       "value": "features"
       },
       {
        "type": "array",
        "value": [
         {
          "type": "string",
-         "value": "https://subject-1.local/spam"
+         "value": "feature-1"
         },
         {
          "type": "string",
-         "value": "https://subject-2.local/spam"
+         "value": "feature-2"
         }
        ]
       }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "os"
+      },
+      {
+       "type": "string",
+       "value": "os"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "os.features"
+      },
+      {
+       "type": "array",
+       "value": [
+        {
+         "type": "string",
+         "value": "os-feature-1"
+        },
+        {
+         "type": "string",
+         "value": "os-feature-2"
+        }
+       ]
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "os.version"
+      },
+      {
+       "type": "string",
+       "value": "os-version"
+      }
+     ],
+     [
+      {
+       "type": "string",
+       "value": "variant"
+      },
+      {
+       "type": "string",
+       "value": "variant"
+      }
      ]
+    ]
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "size"
+   },
+   {
+    "type": "number",
+    "value": 123
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "urls"
+   },
+   {
+    "type": "array",
+    "value": [
+     {
+      "type": "string",
+      "value": "https://config-1.local/spam"
+     },
+     {
+      "type": "string",
+      "value": "https://config-2.local/spam"
+     }
     ]
    }
   ]
@@ -1549,168 +1082,31 @@
   [
    {
     "type": "string",
-    "value": "config"
+    "value": "artifactType"
    },
    {
-    "type": "object",
-    "value": [
-     [
-      {
-       "type": "string",
-       "value": "annotations"
-      },
-      {
-       "type": "object",
-       "value": []
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "artifactType"
-      },
-      {
-       "type": "string",
-       "value": ""
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "data"
-      },
-      {
-       "type": "string",
-       "value": ""
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "digest"
-      },
-      {
-       "type": "string",
-       "value": "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "mediaType"
-      },
-      {
-       "type": "string",
-       "value": "application/vnd.oci.image.config.v1+json"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "size"
-      },
-      {
-       "type": "number",
-       "value": 123
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "urls"
-      },
-      {
-       "type": "array",
-       "value": []
-      }
-     ]
-    ]
+    "type": "string",
+    "value": ""
    }
   ],
   [
    {
     "type": "string",
-    "value": "layers"
+    "value": "data"
    },
    {
-    "type": "array",
-    "value": [
-     {
-      "type": "object",
-      "value": [
-       [
-        {
-         "type": "string",
-         "value": "annotations"
-        },
-        {
-         "type": "object",
-         "value": []
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "artifactType"
-        },
-        {
-         "type": "string",
-         "value": ""
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "data"
-        },
-        {
-         "type": "string",
-         "value": ""
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "digest"
-        },
-        {
-         "type": "string",
-         "value": "sha256:325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67"
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "mediaType"
-        },
-        {
-         "type": "string",
-         "value": "application/vnd.oci.image.layer.v1.tar+gzip"
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "size"
-        },
-        {
-         "type": "number",
-         "value": 9999
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "urls"
-        },
-        {
-         "type": "array",
-         "value": []
-        }
-       ]
-      ]
-     }
-    ]
+    "type": "string",
+    "value": ""
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "digest"
+   },
+   {
+    "type": "string",
+    "value": "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
    }
   ],
   [
@@ -1720,17 +1116,27 @@
    },
    {
     "type": "string",
-    "value": "application/vnd.oci.image.manifest.v1+json"
+    "value": "application/vnd.oci.image.config.v1+json"
    }
   ],
   [
    {
     "type": "string",
-    "value": "schemaVersion"
+    "value": "size"
    },
    {
     "type": "number",
-    "value": 2
+    "value": 123
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "urls"
+   },
+   {
+    "type": "array",
+    "value": []
    }
   ]
  ]
@@ -1754,168 +1160,31 @@
   [
    {
     "type": "string",
-    "value": "config"
+    "value": "artifactType"
    },
    {
-    "type": "object",
-    "value": [
-     [
-      {
-       "type": "string",
-       "value": "annotations"
-      },
-      {
-       "type": "object",
-       "value": []
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "artifactType"
-      },
-      {
-       "type": "string",
-       "value": ""
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "data"
-      },
-      {
-       "type": "string",
-       "value": ""
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "digest"
-      },
-      {
-       "type": "string",
-       "value": "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "mediaType"
-      },
-      {
-       "type": "string",
-       "value": "application/vnd.oci.image.config.v1+json"
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "size"
-      },
-      {
-       "type": "number",
-       "value": 123
-      }
-     ],
-     [
-      {
-       "type": "string",
-       "value": "urls"
-      },
-      {
-       "type": "array",
-       "value": []
-      }
-     ]
-    ]
+    "type": "string",
+    "value": ""
    }
   ],
   [
    {
     "type": "string",
-    "value": "layers"
+    "value": "data"
    },
    {
-    "type": "array",
-    "value": [
-     {
-      "type": "object",
-      "value": [
-       [
-        {
-         "type": "string",
-         "value": "annotations"
-        },
-        {
-         "type": "object",
-         "value": []
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "artifactType"
-        },
-        {
-         "type": "string",
-         "value": ""
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "data"
-        },
-        {
-         "type": "string",
-         "value": ""
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "digest"
-        },
-        {
-         "type": "string",
-         "value": "sha256:325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67"
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "mediaType"
-        },
-        {
-         "type": "string",
-         "value": "application/vnd.oci.image.layer.v1.tar+gzip"
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "size"
-        },
-        {
-         "type": "number",
-         "value": 9999
-        }
-       ],
-       [
-        {
-         "type": "string",
-         "value": "urls"
-        },
-        {
-         "type": "array",
-         "value": []
-        }
-       ]
-      ]
-     }
-    ]
+    "type": "string",
+    "value": ""
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "digest"
+   },
+   {
+    "type": "string",
+    "value": "sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
    }
   ],
   [
@@ -1925,17 +1194,27 @@
    },
    {
     "type": "string",
-    "value": "application/vnd.oci.image.manifest.v1+json"
+    "value": "application/vnd.oci.image.config.v1+json"
    }
   ],
   [
    {
     "type": "string",
-    "value": "schemaVersion"
+    "value": "size"
    },
    {
     "type": "number",
-    "value": 2
+    "value": 123
+   }
+  ],
+  [
+   {
+    "type": "string",
+    "value": "urls"
+   },
+   {
+    "type": "array",
+    "value": []
    }
   ]
  ]

--- a/internal/rego/oci/oci_test.go
+++ b/internal/rego/oci/oci_test.go
@@ -112,145 +112,59 @@ func TestOCIBlob(t *testing.T) {
 
 func TestOCIDescriptorManifest(t *testing.T) {
 	cases := []struct {
-		name        string
-		ref         *ast.Term
-		manifest    *v1.Manifest
-		imageErr    error
-		manifestErr error
-		wantErr     bool
+		name       string
+		ref        *ast.Term
+		descriptor *v1.Descriptor
+		err        error
 	}{
 		{
 			name: "complete image manifest",
 			ref:  ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
-			manifest: &v1.Manifest{
-				SchemaVersion: 2,
-				MediaType:     types.OCIManifestSchema1,
-				Config: v1.Descriptor{
-					MediaType: types.OCIConfigJSON,
-					Size:      123,
-					Digest: v1.Hash{
-						Algorithm: "sha256",
-						Hex:       "4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
-					},
-					Data: []byte(`{"data": "config"}`),
-					URLs: []string{"https://config-1.local/spam", "https://config-2.local/spam"},
-					Annotations: map[string]string{
-						"config.annotation.1": "config.annotation.value.1",
-						"config.annotation.2": "config.annotation.value.2",
-					},
-					Platform: &v1.Platform{
-						Architecture: "arch",
-						OS:           "os",
-						OSVersion:    "os-version",
-						OSFeatures:   []string{"os-feature-1", "os-feature-2"},
-						Variant:      "variant",
-						Features:     []string{"feature-1", "feature-2"},
-					},
-					ArtifactType: "artifact-type",
+			descriptor: &v1.Descriptor{
+				MediaType: types.OCIConfigJSON,
+				Size:      123,
+				Digest: v1.Hash{
+					Algorithm: "sha256",
+					Hex:       "4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
 				},
-				Layers: []v1.Descriptor{
-					{
-						MediaType: types.OCILayer,
-						Size:      9999,
-						Digest: v1.Hash{
-							Algorithm: "sha256",
-							Hex:       "325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67",
-						},
-						Data: []byte(`{"data": "layer"}`),
-						URLs: []string{"https://layer-1.local/spam", "https://layer-2.local/spam"},
-						Annotations: map[string]string{
-							"layer.annotation.1": "layer.annotation.value.1",
-							"layer.annotation.2": "layer.annotation.value.2",
-						},
-						Platform: &v1.Platform{
-							Architecture: "arch",
-							OS:           "os",
-							OSVersion:    "os-version",
-							OSFeatures:   []string{"os-feature-1", "os-feature-2"},
-							Variant:      "variant",
-							Features:     []string{"feature-1", "feature-2"},
-						},
-						ArtifactType: "artifact-type",
-					},
-				},
+				Data: []byte(`{"data": "config"}`),
+				URLs: []string{"https://config-1.local/spam", "https://config-2.local/spam"},
 				Annotations: map[string]string{
-					"manifest.annotation.1": "config.annotation.value.1",
-					"manifest.annotation.2": "config.annotation.value.2",
+					"config.annotation.1": "config.annotation.value.1",
+					"config.annotation.2": "config.annotation.value.2",
 				},
-				Subject: &v1.Descriptor{
-					MediaType: types.OCIManifestSchema1,
-					Size:      8888,
-					Digest: v1.Hash{
-						Algorithm: "sha256",
-						Hex:       "d9298a10d1b0735837dc4bd85dac641b0f3cef27a47e5d53a54f2f3f5b2fcffa",
-					},
-					Data: []byte(`{"data": "subject"}`),
-					URLs: []string{"https://subject-1.local/spam", "https://subject-2.local/spam"},
-					Annotations: map[string]string{
-						"subject.annotation.1": "subject.annotation.value.1",
-						"subject.annotation.2": "subject.annotation.value.2",
-					},
-					Platform: &v1.Platform{
-						Architecture: "arch",
-						OS:           "os",
-						OSVersion:    "os-version",
-						OSFeatures:   []string{"os-feature-1", "os-feature-2"},
-						Variant:      "variant",
-						Features:     []string{"feature-1", "feature-2"},
-					},
-					ArtifactType: "artifact-type",
+				Platform: &v1.Platform{
+					Architecture: "arch",
+					OS:           "os",
+					OSVersion:    "os-version",
+					OSFeatures:   []string{"os-feature-1", "os-feature-2"},
+					Variant:      "variant",
+					Features:     []string{"feature-1", "feature-2"},
 				},
+				ArtifactType: "artifact-type",
 			},
 		},
 		{
 			name: "minimal image manifest",
 			ref:  ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
-			manifest: &v1.Manifest{
-				SchemaVersion: 2,
-				MediaType:     types.OCIManifestSchema1,
-				Config: v1.Descriptor{
-					MediaType: types.OCIConfigJSON,
-					Size:      123,
-					Digest: v1.Hash{
-						Algorithm: "sha256",
-						Hex:       "4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
-					},
-				},
-				Layers: []v1.Descriptor{
-					{
-						MediaType: types.OCILayer,
-						Size:      9999,
-						Digest: v1.Hash{
-							Algorithm: "sha256",
-							Hex:       "325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67",
-						},
-					},
+			descriptor: &v1.Descriptor{
+				MediaType: types.OCIConfigJSON,
+				Size:      123,
+				Digest: v1.Hash{
+					Algorithm: "sha256",
+					Hex:       "4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
 				},
 			},
 		},
 		{
 			name: "minimal image index",
 			ref:  ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
-			manifest: &v1.Manifest{
-				SchemaVersion: 2,
-				MediaType:     types.OCIManifestSchema1,
-				Config: v1.Descriptor{
-					MediaType: types.OCIConfigJSON,
-					Size:      123,
-					Digest: v1.Hash{
-						Algorithm: "sha256",
-						Hex:       "4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
-					},
-				},
-				Layers: []v1.Descriptor{
-					{
-						MediaType: types.OCILayer,
-						Size:      9999,
-						Digest: v1.Hash{
-							Algorithm: "sha256",
-							Hex:       "325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67",
-						},
-					},
+			descriptor: &v1.Descriptor{
+				MediaType: types.OCIConfigJSON,
+				Size:      123,
+				Digest: v1.Hash{
+					Algorithm: "sha256",
+					Hex:       "4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
 				},
 			},
 		},
@@ -259,19 +173,17 @@ func TestOCIDescriptorManifest(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			client := fake.FakeClient{}
-			if c.imageErr != nil {
-				client.On("Head", mock.Anything, mock.Anything).Return(nil, c.imageErr)
+			if c.err != nil {
+				client.On("Head", mock.Anything).Return(nil, c.err)
 			} else {
-				imageManifest := v1fake.FakeImage{}
-				imageManifest.ManifestReturns(c.manifest, c.manifestErr)
-				client.On("Head", mock.Anything, mock.Anything).Return(&imageManifest, nil)
+				client.On("Head", mock.Anything).Return(c.descriptor, nil)
 			}
 			ctx := oci.WithClient(context.Background(), &client)
 			bctx := rego.BuiltinContext{Context: ctx}
 
 			got, err := ociDescriptor(bctx, c.ref)
 			require.NoError(t, err)
-			if c.wantErr {
+			if c.err != nil {
 				require.Nil(t, got)
 			} else {
 				require.NotNil(t, got)
@@ -283,175 +195,33 @@ func TestOCIDescriptorManifest(t *testing.T) {
 
 func TestOCIDescriptorErrors(t *testing.T) {
 	cases := []struct {
-		name        string
-		ref         *ast.Term
-		manifest    *v1.Manifest
-		imageErr    error
-		manifestErr error
-		wantErr     bool
+		name string
+		ref  *ast.Term
 	}{
 		{
-			name:    "missing digest",
-			ref:     ast.StringTerm("registry.local/spam:latest"),
-			wantErr: true,
+			name: "missing digest",
+			ref:  ast.StringTerm("registry.local/spam:latest"),
 		},
 		{
-			name:    "bad image ref",
-			ref:     ast.StringTerm("......registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
-			wantErr: true,
+			name: "bad image ref",
+			ref:  ast.StringTerm("......registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
 		},
 		{
-			name:    "invalid ref type",
-			ref:     ast.IntNumberTerm(42),
-			wantErr: true,
-		},
-		{
-			name:        "image error",
-			ref:         ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
-			manifestErr: errors.New("kaboom!"),
-			wantErr:     true,
-		},
-		{
-			name:     "nil manifest",
-			ref:      ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
-			manifest: nil,
-			wantErr:  true,
+			name: "invalid ref type",
+			ref:  ast.IntNumberTerm(42),
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			client := fake.FakeClient{}
-			if c.imageErr != nil {
-				client.On("Head", mock.Anything, mock.Anything).Return(nil, c.imageErr)
-			} else {
-				imageManifest := v1fake.FakeImage{}
-				imageManifest.ManifestReturns(c.manifest, c.manifestErr)
-				client.On("Head", mock.Anything, mock.Anything).Return(&imageManifest, nil)
-			}
+			client.On("Head", mock.Anything, mock.Anything).Return(nil, errors.New("expected"))
 			ctx := oci.WithClient(context.Background(), &client)
 			bctx := rego.BuiltinContext{Context: ctx}
 
 			got, err := ociDescriptor(bctx, c.ref)
 			require.NoError(t, err)
-			if c.wantErr {
-				require.Nil(t, got)
-			} else {
-				require.NotNil(t, got)
-				snaps.MatchJSON(t, got)
-			}
-		})
-	}
-}
-
-func TestOCIDescriptorIndex(t *testing.T) {
-	cases := []struct {
-		name        string
-		ref         *ast.Term
-		manifest    *v1.IndexManifest
-		imageErr    error
-		manifestErr error
-		wantErr     bool
-	}{
-		{
-			name: "complete image index",
-			ref:  ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
-			manifest: &v1.IndexManifest{
-				SchemaVersion: 2,
-				MediaType:     types.OCIImageIndex,
-				Manifests: []v1.Descriptor{
-					{
-						MediaType: types.OCIManifestSchema1,
-						Size:      123,
-						Digest: v1.Hash{
-							Algorithm: "sha256",
-							Hex:       "4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
-						},
-						Annotations: map[string]string{
-							"config.annotation.1": "config.annotation.value.1",
-							"config.annotation.2": "config.annotation.value.2",
-						},
-						Platform: &v1.Platform{
-							Architecture: "arch",
-							OS:           "os",
-							OSVersion:    "os-version",
-							OSFeatures:   []string{"os-feature-1", "os-feature-2"},
-							Variant:      "variant",
-							Features:     []string{"feature-1", "feature-2"},
-						},
-						ArtifactType: "artifact-type",
-					},
-				},
-				Annotations: map[string]string{
-					"manifest.annotation.1": "config.annotation.value.1",
-					"manifest.annotation.2": "config.annotation.value.2",
-				},
-				Subject: &v1.Descriptor{
-					MediaType: types.OCIManifestSchema1,
-					Size:      8888,
-					Digest: v1.Hash{
-						Algorithm: "sha256",
-						Hex:       "d9298a10d1b0735837dc4bd85dac641b0f3cef27a47e5d53a54f2f3f5b2fcffa",
-					},
-					Data: []byte(`{"data": "subject"}`),
-					URLs: []string{"https://subject-1.local/spam", "https://subject-2.local/spam"},
-					Annotations: map[string]string{
-						"subject.annotation.1": "subject.annotation.value.1",
-						"subject.annotation.2": "subject.annotation.value.2",
-					},
-					Platform: &v1.Platform{
-						Architecture: "arch",
-						OS:           "os",
-						OSVersion:    "os-version",
-						OSFeatures:   []string{"os-feature-1", "os-feature-2"},
-						Variant:      "variant",
-						Features:     []string{"feature-1", "feature-2"},
-					},
-					ArtifactType: "artifact-type",
-				},
-			},
-		},
-		{
-			name: "minimal image index",
-			ref:  ast.StringTerm("registry.local/spam:latest@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"),
-			manifest: &v1.IndexManifest{
-				SchemaVersion: 2,
-				MediaType:     types.OCIImageIndex,
-				Manifests: []v1.Descriptor{
-					{
-						MediaType: types.OCILayer,
-						Size:      9999,
-						Digest: v1.Hash{
-							Algorithm: "sha256",
-							Hex:       "325392e8dd2826a53a9a35b7a7f8d71683cd27ebc2c73fee85dab673bc909b67",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			client := fake.FakeClient{}
-			if c.imageErr != nil {
-				client.On("Head", mock.Anything, mock.Anything).Return(nil, c.imageErr)
-			} else {
-				imageIndex := v1fake.FakeImageIndex{}
-				imageIndex.IndexManifestReturns(c.manifest, c.manifestErr)
-				client.On("Head", mock.Anything, mock.Anything).Return(&imageIndex, nil)
-			}
-			ctx := oci.WithClient(context.Background(), &client)
-			bctx := rego.BuiltinContext{Context: ctx}
-
-			got, err := ociDescriptor(bctx, c.ref)
-			require.NoError(t, err)
-			if c.wantErr {
-				require.Nil(t, got)
-			} else {
-				require.NotNil(t, got)
-				snaps.MatchJSON(t, got)
-			}
+			require.Nil(t, got)
 		})
 	}
 }


### PR DESCRIPTION
Some OCI artifacts need to have a specific media type (i.e. they should
only be an OCI image index or an OCI image manifest). In order to
determine that with a single remote call, we can just get the descriptor
and then check the mediaType of that object.

Signed-off-by: arewm <arewm@users.noreply.github.com>